### PR TITLE
adde a new parser in python

### DIFF
--- a/database/fecDataImport.config
+++ b/database/fecDataImport.config
@@ -1,0 +1,5 @@
+[DEFAULT]
+url = https://www.fec.gov/files/bulk-downloads/
+outPath = /Users/Dan/Desktop/dataDump/
+startYear = 2014
+endYear = 2018

--- a/database/getfecdata.py
+++ b/database/getfecdata.py
@@ -1,0 +1,78 @@
+import configparser
+import argparse
+import subprocess
+import datetime
+
+class dataImporter:
+    def __init__(self, config):
+        print("test")
+
+class dataFetcher:
+    def __init__(self, config, profile="DEFAULT"):
+        self.config = config[profile]
+        self.url = self.config["url"]
+        self.outPath = self.config["outPath"]
+        self.startYear = int(self.config["startYear"])
+        self.endYear = int(self.config["endYear"])
+        self.years = [str(year) for year in range(self.startYear, self.endYear+1)]
+        self._dataTypes = [\
+            {"type":"cn","format":".zip","description":""},\
+            {"type":"cm","format":".zip","description":""},\
+            {"type":"oppexp","format":".zip","description":""},\
+            {"type":"oth","format":".zip","description":""},\
+            {"type":"indiv","format":".zip","description":""},\
+            {"type":"pas2","format":".zip","description":""}
+        ]
+
+    def _constructFilePath(self, type, format, url, year):
+        _path = url + year + "/" + type + year[-2:] + format
+        return _path
+
+    def _constructAllFilePaths(self, dataTypes, url, year):
+        _filePaths = []
+        for _dataType in dataTypes:
+            _filePaths.append(self._constructFilePath(_dataType["type"], _dataType["format"], url, year))
+        return _filePaths
+
+    def _constructHeaderPath(self, type, url):
+        _path = url + "data_dictionaries/" + type + "_header_file.csv"
+        return _path
+
+    def _constructAllHeaderPaths(self, dataTypes, url):
+        _headerPaths = []
+        for _dataType in dataTypes:
+            _headerPaths.append(self._constructHeaderPath(_dataType["type"], url))
+        return _headerPaths
+
+    def _fetchFile(self, url, outPath):
+        directory = (outPath.split(outPath.split("/")[-1], 1)[0])
+        subprocess.call(["mkdir", directory])
+        subprocess.call(["wget", url, "-O", outPath])
+        
+
+    def _fetchFilesInYear(self, year):
+        _allPaths = self._constructAllFilePaths(self._dataTypes, self.url, year)
+        for _path in _allPaths:
+            self._fetchFile(_path, self.outPath + _path.split(self.url, 1)[1])
+        
+    def _fetchHeaderFiles(self):
+        _allHeaderPaths = self._constructAllHeaderPaths(self._dataTypes, self.url)
+        for _headerPath in _allHeaderPaths:
+            self._fetchFile(_headerPath, self.outPath + _headerPath.split(self.url, 1)[1])
+
+    def fetchData(self):
+        for year in self.years:
+            self._fetchFilesInYear(year)
+        self._fetchHeaderFiles()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='download FEC data and load it into a database')
+    parser.add_argument('config', type=str, help='an absolute path to the governet FEC importer configuration file')
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser()
+    config.read(args.config)
+
+    d = dataFetcher(config)
+    
+    d.fetchData()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   node:
-    build: ./backend/.
+    build: ./server/.
     networks: 
       - governetwork
     ports:
@@ -15,14 +15,13 @@ services:
     networks:
       - governetwork
   frontend:
-    build: ./frontend/.
+    build: ./client/.
     ports:
       - 5000:5000
     networks:
       - governetwork
     depends_on:
       - "mongodb"
-
 networks:
   governetwork:
     driver: bridge


### PR DESCRIPTION
Created the first part of a new data fetch and parsing, written in python.
Previously this was written as an obtuse shell script, that did not allow for easy modification. 
The new version is written in python, and accepts a configuration file which tells it what years to download and where to save them.  When executed, this will then fetch all of the given data from the years provided and save them to the out path.  
Currently, this does not unzip and clean the data.  The ETL will be handled in another set of scripts and classes.
Yet to come:
Eventually, this will download the data and parse it, all contained in a python data loading container.  This container will then load the data into a database, provided in the config file.  We can set the config file values with docker environment variables.  The container will run the download and processes, load the data into the given database container based on the config file, and then terminate once it's confirmed completed.  